### PR TITLE
fix width of "get docker" blocks on `max-width: 768px` views

### DIFF
--- a/get-docker.md
+++ b/get-docker.md
@@ -22,7 +22,7 @@ section and choose the best installation path for you.
 <div class="component-container">
     <!--start row-->
     <div class="row">
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/desktop/mac/install/"><img src="/images/apple_48.svg" alt="Docker Desktop for Mac" width="70" height="70"></a>
@@ -31,7 +31,7 @@ section and choose the best installation path for you.
                 <p>A native application using the macOS sandbox security model which delivers all Docker tools to your Mac.</p>
             </div>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/desktop/windows/install/"><img src="/images/windows_48.svg" alt="Docker Desktop for Windows" width="70" height="70"></a>
@@ -40,7 +40,7 @@ section and choose the best installation path for you.
                 <p>A native Windows application which delivers all Docker tools to your Windows computer.</p>
             </div>
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-4 block">
+        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-4 block">
             <div class="component">
                 <div class="component-icon">
                     <a href="/engine/install/"><img src="/images/linux_48.svg" alt="Docker for Linux" width="70" height="70"></a>


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes
Fixes the width of the "get docker" blocks on `max-width: 768px` by adding a `col-xs-12` class to the `.blocks` elements which will give them a `width: 100%` on smaller screens resolving the yucky width issue.
<!--Tell us what you did and why-->
See https://github.com/docker/docker.github.io/pull/13452#issuecomment-910895953
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)
Hopefully closes #13433 and resolves #13432
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->

@thaJeztah 